### PR TITLE
Improve Testing and Fixing Metastore backend for test

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+;max-complexity = 8
+exclude = .venv*,venv*,.git,__pycache__,.tox,.eggs,*.egg

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,4 @@
 [settings]
+line_length = 120
 known_first_party = ckanext.versioning
-known_third_party = ckan
+known_third_party = ckan,metastore

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,25 @@ PIP := pip
 ISORT := isort
 FLAKE8 := flake8
 NOSETESTS := nosetests
-SED := sed
 PASTER := paster
+DOCKER_COMPOSE := docker-compose
+
+# Find GNU sed in path (on OS X gsed should be preferred)
+SED := $(shell which gsed sed | head -n1)
 
 TEST_INI_PATH := ./test.ini
-CKAN_PATH := ../../src/ckan
+CKAN_PATH := ../ckan
 TEST_PATH :=
+
+# These are used in creating .env file and ckan config
+CKAN_SITE_URL := http://localhost:5000
+POSTGRES_USER := ckan
+POSTGRES_PASSWORD := ckan
+POSTGRES_DB := ckan
+CKAN_SOLR_PASSWORD := ckan
+DATASTORE_DB_NAME := datastore
+DATASTORE_DB_RO_USER := datastore_ro
+DATASTORE_DB_RO_PASSWORD := datastore_ro
 
 prepare-config:
 	$(SED) "s@use = config:.*@use = config:$(CKAN_PATH)/test-core.ini@" -i $(TEST_INI_PATH)
@@ -37,3 +50,36 @@ coverage: prepare-config test
           --cover-inclusive \
           --cover-erase \
           --cover-tests
+
+.env:
+	@___POSTGRES_USER=$(POSTGRES_USER) \
+	___POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
+	___POSTGRES_DB=$(POSTGRES_DB) \
+	___CKAN_SOLR_PASSWORD=$(CKAN_SOLR_PASSWORD) \
+	___DATASTORE_DB_NAME=$(DATASTORE_DB_NAME) \
+	___DATASTORE_DB_USER=$(POSTGRES_USER) \
+	___DATASTORE_DB_RO_USER=$(DATASTORE_DB_RO_USER) \
+	___DATASTORE_DB_RO_PASSWORD=$(DATASTORE_DB_RO_PASSWORD) \
+	env | grep ^___ | $(SED) 's/^___//' > .env
+	@cat .env
+
+## Start all Docker services
+docker-up: .env
+	$(DOCKER_COMPOSE) up -d
+	@until $(DOCKER_COMPOSE) exec db pg_isready -U $(POSTGRES_USER); do sleep 1; done
+	@sleep 2
+	@echo " \
+    	CREATE ROLE $(DATASTORE_DB_RO_USER) NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '$(DATASTORE_DB_RO_PASSWORD)'; \
+    	CREATE DATABASE $(DATASTORE_DB_NAME) OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	CREATE DATABASE $(DATASTORE_DB_NAME)_test OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	CREATE DATABASE $(POSTGRES_DB)_test OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	GRANT ALL PRIVILEGES ON DATABASE $(DATASTORE_DB_NAME) TO $(POSTGRES_USER);  \
+    	GRANT ALL PRIVILEGES ON DATABASE $(DATASTORE_DB_NAME)_test TO $(POSTGRES_USER);  \
+    	GRANT ALL PRIVILEGES ON DATABASE $(POSTGRES_DB)_test TO $(POSTGRES_USER);  \
+    " | $(DOCKER_COMPOSE) exec -T db psql --username "$(POSTGRES_USER)"
+.PHONY: docker-up
+
+## Stop all Docker services
+docker-down: .env
+	$(DOCKER_COMPOSE) down
+.PHONY: docker-down

--- a/ckanext/versioning/common.py
+++ b/ckanext/versioning/common.py
@@ -1,7 +1,6 @@
 from ast import literal_eval
 
 from ckan.plugins import toolkit
-
 from metastore.backend import create_metastore
 from metastore.types import Author
 
@@ -13,9 +12,13 @@ def get_metastore_backend():
     configuration file of CKAN.
     '''
     backend_type = toolkit.config.get('ckanext.versioning.backend_type')
-    config = literal_eval(
-        toolkit.config.get('ckanext.versioning.backend_config')
+    try:
+        config = literal_eval(
+            toolkit.config.get('ckanext.versioning.backend_config')
         )
+    except ValueError:
+        config = {}
+
     return create_metastore(backend_type, config)
 
 

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -11,8 +11,7 @@ from ckan.logic.action.get import resource_show as core_resource_show
 from ckan.plugins import toolkit
 from sqlalchemy.exc import IntegrityError
 
-from ckanext.versioning.common import (create_author_from_context,
-                                       get_metastore_backend)
+from ckanext.versioning.common import create_author_from_context, get_metastore_backend
 from ckanext.versioning.logic import helpers as h
 from ckanext.versioning.model import DatasetVersion
 

--- a/ckanext/versioning/logic/helpers.py
+++ b/ckanext/versioning/logic/helpers.py
@@ -1,8 +1,7 @@
 from ckan import model
 from ckan.plugins import toolkit
 
-from ckanext.versioning.lib.changes import (check_metadata_changes,
-                                            check_resource_changes)
+from ckanext.versioning.lib.changes import check_metadata_changes, check_resource_changes
 
 
 def url_for_version(package, version=None, **kwargs):

--- a/ckanext/versioning/model.py
+++ b/ckanext/versioning/model.py
@@ -6,8 +6,7 @@ from collections import OrderedDict
 
 from ckan.model.meta import metadata
 from ckan.model.types import UuidType
-from sqlalchemy import (Column, DateTime, ForeignKey, Unicode,
-                        UniqueConstraint, orm)
+from sqlalchemy import Column, DateTime, ForeignKey, Unicode, UniqueConstraint, orm
 from sqlalchemy.ext.declarative import declarative_base
 
 log = logging.getLogger(__name__)

--- a/ckanext/versioning/plugin.py
+++ b/ckanext/versioning/plugin.py
@@ -8,8 +8,7 @@ from ckan.lib.uploader import ALLOWED_UPLOAD_TYPES
 from ckan_datapackage_tools import converter
 
 from ckanext.versioning import blueprints
-from ckanext.versioning.common import (create_author_from_context,
-                                       get_metastore_backend)
+from ckanext.versioning.common import create_author_from_context, get_metastore_backend
 from ckanext.versioning.logic import action, auth, helpers, uploader
 from ckanext.versioning.model import tables_exist
 
@@ -18,7 +17,8 @@ UPLOAD_TS_FIELD = uploader.UPLOAD_TS_FIELD
 log = logging.getLogger(__name__)
 
 
-class PackageVersioningPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
+class PackageVersioningPlugin(plugins.SingletonPlugin,
+                              toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)

--- a/ckanext/versioning/tests/__init__.py
+++ b/ckanext/versioning/tests/__init__.py
@@ -1,3 +1,8 @@
+import json
+import shutil
+import tempfile
+
+from ckan.common import config
 from ckan.tests import helpers
 
 from ckanext.versioning import model
@@ -11,3 +16,15 @@ class FunctionalTestBase(helpers.FunctionalTestBase):
         if not model.tables_exist():
             model.create_tables()
         super(FunctionalTestBase, self).setup()
+
+
+class TestWithMetastoreBackend(FunctionalTestBase):
+
+    def setup(self):
+        super(TestWithMetastoreBackend, self).setup()
+        self._backend_dir = tempfile.mkdtemp()
+        config['ckanext.versioning.backend_config'] = json.dumps({"uri": self._backend_dir})
+
+    def teardown(self):
+        super(TestWithMetastoreBackend, self).setup()
+        shutil.rmtree(self._backend_dir)

--- a/ckanext/versioning/tests/__init__.py
+++ b/ckanext/versioning/tests/__init__.py
@@ -18,13 +18,13 @@ class FunctionalTestBase(helpers.FunctionalTestBase):
         super(FunctionalTestBase, self).setup()
 
 
-class TestWithMetastoreBackend(FunctionalTestBase):
+class MetastoreBackendTestBase(FunctionalTestBase):
 
     def setup(self):
-        super(TestWithMetastoreBackend, self).setup()
+        super(MetastoreBackendTestBase, self).setup()
         self._backend_dir = tempfile.mkdtemp()
         config['ckanext.versioning.backend_config'] = json.dumps({"uri": self._backend_dir})
 
     def teardown(self):
-        super(TestWithMetastoreBackend, self).setup()
+        super(MetastoreBackendTestBase, self).setup()
         shutil.rmtree(self._backend_dir)

--- a/ckanext/versioning/tests/test_action.py
+++ b/ckanext/versioning/tests/test_action.py
@@ -3,10 +3,11 @@ from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
 from nose.tools import assert_equals, assert_in, assert_raises
 
-from ckanext.versioning.tests import TestWithMetastoreBackend
+from ckanext.versioning.common import get_metastore_backend
+from ckanext.versioning.tests import MetastoreBackendTestBase
 
 
-class TestVersionsActions(TestWithMetastoreBackend):
+class TestVersionsActions(MetastoreBackendTestBase):
     """Test cases for logic actions
     """
 
@@ -36,6 +37,15 @@ class TestVersionsActions(TestWithMetastoreBackend):
         )
 
         self.dataset = factories.Dataset()
+
+    def test_create_stores_a_revision_in_metastore(self):
+        """Test that creating a new dataset creates a revision in metastore
+        """
+        backend = get_metastore_backend()
+        dataset = backend.fetch(self.dataset['name'])
+
+        assert_equals(self.dataset['name'], dataset.package['name'])
+        assert_equals(self.dataset['notes'], dataset.package['description'])
 
     def test_create_tag(self):
         """Test basic dataset version creation
@@ -343,7 +353,7 @@ class TestVersionsActions(TestWithMetastoreBackend):
         )
 
 
-class TestVersionsPromote(TestWithMetastoreBackend):
+class TestVersionsPromote(MetastoreBackendTestBase):
     """Test cases for promoting a dataset version to latest
     """
 

--- a/ckanext/versioning/tests/test_action.py
+++ b/ckanext/versioning/tests/test_action.py
@@ -3,10 +3,10 @@ from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
 from nose.tools import assert_equals, assert_in, assert_raises
 
-from ckanext.versioning.tests import FunctionalTestBase
+from ckanext.versioning.tests import TestWithMetastoreBackend
 
 
-class TestVersionsActions(FunctionalTestBase):
+class TestVersionsActions(TestWithMetastoreBackend):
     """Test cases for logic actions
     """
 
@@ -20,7 +20,6 @@ class TestVersionsActions(FunctionalTestBase):
         }
 
     def setup(self):
-
         super(TestVersionsActions, self).setup()
 
         self.org_admin = factories.User()
@@ -38,7 +37,7 @@ class TestVersionsActions(FunctionalTestBase):
 
         self.dataset = factories.Dataset()
 
-    def test_create(self):
+    def test_create_tag(self):
         """Test basic dataset version creation
         """
         context = self._get_context(self.org_admin)
@@ -56,7 +55,7 @@ class TestVersionsActions(FunctionalTestBase):
                       "The best dataset ever, it **rules!**")
         assert_equals(version['creator_user_id'], self.org_admin['id'])
 
-    def test_create_name_already_exists(self):
+    def test_create_tag_name_already_exists(self):
         """Test that creating a version with an existing name for the same
         dataset raises an error
         """
@@ -344,7 +343,7 @@ class TestVersionsActions(FunctionalTestBase):
         )
 
 
-class TestVersionsPromote(FunctionalTestBase):
+class TestVersionsPromote(TestWithMetastoreBackend):
     """Test cases for promoting a dataset version to latest
     """
 

--- a/ckanext/versioning/tests/test_auth.py
+++ b/ckanext/versioning/tests/test_auth.py
@@ -4,10 +4,10 @@ from ckan.tests import factories, helpers
 from nose.tools import assert_raises
 from parameterized import parameterized
 
-from ckanext.versioning.tests import TestWithMetastoreBackend
+from ckanext.versioning.tests import MetastoreBackendTestBase
 
 
-class TestVersionsAuth(TestWithMetastoreBackend):
+class TestVersionsAuth(MetastoreBackendTestBase):
 
     def _get_context(self, user):
         return {

--- a/ckanext/versioning/tests/test_auth.py
+++ b/ckanext/versioning/tests/test_auth.py
@@ -4,10 +4,10 @@ from ckan.tests import factories, helpers
 from nose.tools import assert_raises
 from parameterized import parameterized
 
-from ckanext.versioning.tests import FunctionalTestBase
+from ckanext.versioning.tests import TestWithMetastoreBackend
 
 
-class TestVersionsAuth(FunctionalTestBase):
+class TestVersionsAuth(TestWithMetastoreBackend):
 
     def _get_context(self, user):
         return {

--- a/ckanext/versioning/tests/test_helpers.py
+++ b/ckanext/versioning/tests/test_helpers.py
@@ -2,10 +2,10 @@ from ckan.tests import factories
 from nose.tools import assert_equals
 
 from ckanext.versioning.logic import helpers
-from ckanext.versioning.tests import TestWithMetastoreBackend
+from ckanext.versioning.tests import MetastoreBackendTestBase
 
 
-class TestHelpers(TestWithMetastoreBackend):
+class TestHelpers(MetastoreBackendTestBase):
 
     def setup(self):
         super(TestHelpers, self).setup()

--- a/ckanext/versioning/tests/test_helpers.py
+++ b/ckanext/versioning/tests/test_helpers.py
@@ -2,10 +2,10 @@ from ckan.tests import factories
 from nose.tools import assert_equals
 
 from ckanext.versioning.logic import helpers
-from ckanext.versioning.tests import FunctionalTestBase
+from ckanext.versioning.tests import TestWithMetastoreBackend
 
 
-class TestHelpers(FunctionalTestBase):
+class TestHelpers(TestWithMetastoreBackend):
 
     def setup(self):
         super(TestHelpers, self).setup()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+# Docker Compose file for ckanext-versioning
+# ------------------------------------------------
+# The purpose of this docker-compose file is to simplify setting up a
+# development environment for this CKAN extension; It defines Docker based
+# services for all external CKAN dependencies (DB, Solr, Redis) but not for
+# CKAN itself - you should probably run CKAN in a local virtual environment
+# to simplify debugging.
+
+version: "3"
+
+volumes:
+  db_data:
+
+services:
+
+  db:
+    image: postgres:9-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  solr:
+    image: ckan/solr
+    environment:
+      - CKAN_SOLR_PASSWORD=${CKAN_SOLR_PASSWORD}
+    ports:
+      - 8983:8983
+
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ckan-datapackage-tools==0.1.0
+git+https://github.com/datopian/metastore-lib.git@master#egg=metastore-lib
+python-dateutil==2.8.1
+datapackage

--- a/test.ini
+++ b/test.ini
@@ -15,6 +15,9 @@ use = config:../../src/ckan/test-core.ini
 # tests here.
 
 
+ckanext.versioning.backend_type = filesystem
+ckanext.versioning.backend_config = {"uri":"/tmp/versioning-storage/"}
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy


### PR DESCRIPTION
This PR improves testing:

- Adds a proper metastore backend to be used by test
- Adds a simple test to check that metastore is being called when creating a package.