### PR TITLE
Ui Refactor - Add route for versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CKAN_SOLR_PASSWORD := ckan
 DATASTORE_DB_NAME := datastore
 DATASTORE_DB_RO_USER := datastore_ro
 DATASTORE_DB_RO_PASSWORD := datastore_ro
-CKAN_LOAD_PLUGINS := stats text_view image_view recline_view datastore
+CKAN_LOAD_PLUGINS := stats text_view image_view recline_view datastore package_versioning resource_versioning
 
 CKAN_CONFIG_VALUES := \
 		ckan.site_url=$(CKAN_SITE_URL) \
@@ -213,6 +213,11 @@ $(SENTINELS)/tests-passed: $(SENTINELS)/test-setup $(shell find $(PACKAGE_DIR) -
           --with-doctest \
 		  $(COVERAGE_ARG) $(PACKAGE_DIR)/tests/$(TEST_PATH)
 	@touch $@
+
+## Add test users
+add-users: | _check_virtualenv
+	$(PASTER) --plugin=ckan user add admin password=12345678 email=admin@gatesfoundation.org -c $(CKAN_CONFIG_FILE)
+	$(PASTER) --plugin=ckan sysadmin add admin -c $(CKAN_CONFIG_FILE)
 
 # Help related variables and targets
 

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ docker-down: .env
 	$(DOCKER_COMPOSE) down
 .PHONY: docker-down
 
+## Stop all Docker services and remove volumes
+docker-remove: .env
+	$(DOCKER_COMPOSE) down -v
+.PHONY: docker-remove
+
 ## Initialize the development environment
 dev-setup: _check_virtualenv $(SENTINELS)/ckan-installed $(CKAN_PATH)/who.ini $(CKAN_CONFIG_FILE) $(SENTINELS)/develop
 .PHONY: dev-setup
@@ -216,7 +221,7 @@ $(SENTINELS)/tests-passed: $(SENTINELS)/test-setup $(shell find $(PACKAGE_DIR) -
 
 ## Add test users
 add-users: | _check_virtualenv
-	$(PASTER) --plugin=ckan user add admin password=12345678 email=admin@gatesfoundation.org -c $(CKAN_CONFIG_FILE)
+	$(PASTER) --plugin=ckan user add admin password=12345678 email=admin@admin.org -c $(CKAN_CONFIG_FILE)
 	$(PASTER) --plugin=ckan sysadmin add admin -c $(CKAN_CONFIG_FILE)
 
 # Help related variables and targets

--- a/ckanext/versioning/blueprints.py
+++ b/ckanext/versioning/blueprints.py
@@ -5,7 +5,7 @@ from flask import Blueprint
 
 versioning = Blueprint('versioning', __name__)
 
-def show(package_id, revision_id=None):
+def show(package_id, revision_ref=None):
     context = {
         'model': model, 'session': model.Session,
         'user': toolkit.c.user, 'for_view': True,
@@ -13,8 +13,8 @@ def show(package_id, revision_id=None):
     }
 
     data_dict = {'id':package_id, 'include_tracking': True}
-    if revision_id:
-        data_dict['revision_id'] = revision_id
+    if revision_ref:
+        data_dict['revision_ref'] = revision_ref
 
     pkg_dict = toolkit.get_action('package_show')(context, data_dict)
 
@@ -75,4 +75,4 @@ def changes(id):
 
 versioning.add_url_rule('/dataset/<id>/version/changes', view_func=changes)
 versioning.add_url_rule('/dataset/<package_id>/show', view_func=show)
-versioning.add_url_rule('/dataset/<package_id>/show/<revision_id>', view_func=show)
+versioning.add_url_rule('/dataset/<package_id>/show/<revision_ref>', view_func=show)

--- a/ckanext/versioning/blueprints.py
+++ b/ckanext/versioning/blueprints.py
@@ -5,6 +5,23 @@ from flask import Blueprint
 
 versioning = Blueprint('versioning', __name__)
 
+def show(package_id, revision_id=None):
+    context = {
+        'model': model, 'session': model.Session,
+        'user': toolkit.c.user, 'for_view': True,
+        'auth_user_obj': toolkit.c.userobj
+    }
+
+    data_dict = {'id':package_id, 'include_tracking': True}
+    if revision_id:
+        data_dict['revision_id'] = revision_id
+
+    pkg_dict = toolkit.get_action('package_show')(context, data_dict)
+
+    toolkit.c.pkg_dict = pkg_dict
+
+    return toolkit.render('package/read.html')
+
 
 def changes(id):
     context = {
@@ -57,3 +74,5 @@ def changes(id):
 
 
 versioning.add_url_rule('/dataset/<id>/version/changes', view_func=changes)
+versioning.add_url_rule('/dataset/<package_id>/show', view_func=show)
+versioning.add_url_rule('/dataset/<package_id>/show/<revision_id>', view_func=show)

--- a/ckanext/versioning/datapackage.py
+++ b/ckanext/versioning/datapackage.py
@@ -1,0 +1,29 @@
+"""Frictionless Data datapackage.json related functions
+
+See http://specs.frictionlessdata.io/data-package/ for datapackage specs
+"""
+import frictionless_ckan_mapper.ckan_to_frictionless as ctf
+import frictionless_ckan_mapper.frictionless_to_ckan as ftc
+
+
+def dataset_to_frictionless(package):
+    """Convert a CKAN dataset dict to a Frictionless datapackage
+    """
+    # TODO: Use ckan_mapper
+    #return ctf.dataset(package)
+    return package
+
+
+def frictionless_to_dataset(package):
+    """Convert a Frictionless data datapackage dict to a CKAN dataset dict
+    """
+    # TODO: Use ckan_mapper
+    #return ftc.package(package)
+    return package
+
+
+def update_ckan_dict(ckan_dict, dataset):
+    """ Updates the CKAN package dict with metadata from metastore.
+    """
+    ckan_dict.update(dataset)
+    return ckan_dict

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -15,6 +15,7 @@ from metastore.backend.exc import Conflict
 from sqlalchemy.exc import IntegrityError
 
 from ckanext.versioning.common import create_author_from_context, get_metastore_backend
+from ckanext.versioning.datapackage import frictionless_to_dataset, update_ckan_dict
 from ckanext.versioning.logic import helpers as h
 from ckanext.versioning.model import DatasetVersion
 
@@ -271,21 +272,18 @@ def package_show_revision(context, data_dict):
     Takes the same arguments as 'package_show' but with an additional
     revision ID parameter
 
-    Revision ID can also be specified as part of the package ID, as
-    <package_id>@<revision_id>.
-
     :param id: the id of the package
     :type id: string
-    :param revision_id: the ID of the revision
-    :type revision_id: string
+    :param revision_ref: the ID of the revision
+    :type revision_ref: string
     :returns: A package dict
     :rtype: dict
     """
-    revision_id = data_dict.get('revision_id')
-    if revision_id is None:
+    revision_ref = data_dict.get('revision_ref')
+    if revision_ref is None:
         result = core_package_show(context, data_dict)
     else:
-        result = _get_package_in_revision(context, data_dict, revision_id)
+        result = _get_package_in_revision(context, data_dict, revision_ref)
 
     return result
 
@@ -372,8 +370,8 @@ def _get_package_in_revision(context, data_dict, revision_id):
         backend = get_metastore_backend()
         dataset_name = _get_dataset_name(data_dict.get('id'))
         pkg_info = backend.fetch(dataset_name, revision_id)
-        dp = datapackage.DataPackage(pkg_info.package)
-        result.update(converter.datapackage_to_dataset(dp))
+        dataset = frictionless_to_dataset(pkg_info.package)
+        result = update_ckan_dict(result, dataset)
         for resource in result.get('resources', []):
             resource['datastore_active'] = False
             _fix_resource_data(resource, revision_id)

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -178,7 +178,7 @@ def dataset_version_promote(context, data_dict):
 
     revision_dict = toolkit.get_action('package_show')(context, {
         'id': version.package_id,
-        'revision_id': version.package_revision_id
+        'revision_ref': version.package_revision_id
     })
 
     promoted_dataset = toolkit.get_action('package_update')(

--- a/ckanext/versioning/logic/helpers.py
+++ b/ckanext/versioning/logic/helpers.py
@@ -3,6 +3,7 @@ from ckan.plugins import toolkit
 
 from ckanext.versioning.common import get_metastore_backend
 from ckanext.versioning.lib.changes import check_metadata_changes, check_resource_changes
+from ckanext.versioning.model import DatasetVersion
 
 
 def url_for_version(package, version=None, **kwargs):
@@ -19,7 +20,7 @@ def url_for_version(package, version=None, **kwargs):
     name; Otherwise, `controller` and `action` are expected as arguments.
     """
     if version:
-        kwargs['revision_id'] = version['package_revision_id']
+        kwargs['revision_ref'] = version['package_revision_id']
     kwargs['package_id'] = package.get('name', package['id'])
 
     if 'route_name' in kwargs:
@@ -115,3 +116,16 @@ def get_dataset_current_revision(dataset_name):
     backend = get_metastore_backend()
 
     return backend.fetch(dataset_name).revision
+
+def get_dataset_version(package_id, revision_ref):
+    '''Get the DatasetVersion for a package and revision_ref.
+    '''
+    version = model.Session.query(DatasetVersion). \
+                filter(DatasetVersion.package_id == package_id). \
+                filter(DatasetVersion.package_revision_id == revision_ref). \
+                one_or_none()
+
+    if not version:
+        raise toolkit.ObjectNotFound('Version not found')
+
+    return version.as_dict()

--- a/ckanext/versioning/logic/helpers.py
+++ b/ckanext/versioning/logic/helpers.py
@@ -19,17 +19,14 @@ def url_for_version(package, version=None, **kwargs):
     name; Otherwise, `controller` and `action` are expected as arguments.
     """
     if version:
-        package_id = "@".join([package['id'], version['package_revision_id']])
-        if 'version' not in kwargs:
-            kwargs['version'] = version['id']
-    else:
-        package_id = package.get('name', package['id'])
+        kwargs['revision_id'] = version['package_revision_id']
+    kwargs['package_id'] = package.get('name', package['id'])
 
     if 'route_name' in kwargs:
         route = kwargs.pop('route_name')
-        return toolkit.url_for(route, id=package_id, **kwargs)
+        return toolkit.url_for(route, **kwargs)
     else:
-        return toolkit.url_for(id=package_id, **kwargs)
+        return toolkit.url_for(**kwargs)
 
 
 def url_for_resource_version(package, version, **kwargs):

--- a/ckanext/versioning/templates/package/snippets/update_version.html
+++ b/ckanext/versioning/templates/package/snippets/update_version.html
@@ -5,7 +5,7 @@
         <form class="update-version-form">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="updateVersionModalLabel">Edit Version {{ c.current_version.name }} of dataset {{ c.pkg.name }}</h4>
+            <h4 class="modal-title" id="updateVersionModalLabel">Edit Version {{ c.current_version.name }} of dataset {{ c.pkg_dict.name }}</h4>
           </div>
           <div class="modal-body">
             <div class="form-group">

--- a/ckanext/versioning/templates/package/snippets/versions_list.html
+++ b/ckanext/versioning/templates/package/snippets/versions_list.html
@@ -27,7 +27,7 @@
         {% for version in versions %}
           <tr>
             <th scope="row" class="dataset-label">
-              <a href="{{ h.url_for_version(pkg, version=version, controller='package', action='read') }}">
+              <a href="{{ h.url_for_version(pkg, version=version, route_name='versioning.show') }}">
                 {{ version.name }}
               </a>
             </th>

--- a/ckanext/versioning/tests/__init__.py
+++ b/ckanext/versioning/tests/__init__.py
@@ -11,8 +11,6 @@ from ckanext.versioning import model
 
 class FunctionalTestBase(helpers.FunctionalTestBase):
 
-    _load_plugins = ['package_versioning', 'resource_versioning']
-
     def setup(self):
         if not model.tables_exist():
             model.create_tables()

--- a/ckanext/versioning/tests/test_action.py
+++ b/ckanext/versioning/tests/test_action.py
@@ -30,15 +30,6 @@ class TestVersionsActions(MetastoreBackendTestBase):
 
         self.dataset = factories.Dataset()
 
-    def test_create_stores_a_revision_in_metastore(self):
-        """Test that creating a new dataset creates a revision in metastore
-        """
-        backend = get_metastore_backend()
-        dataset = backend.fetch(self.dataset['name'])
-
-        assert_equals(self.dataset['name'], dataset.package['name'])
-        assert_equals(self.dataset['notes'], dataset.package['description'])
-
     def test_create_tag(self):
         """Test basic dataset version creation
         """
@@ -421,7 +412,7 @@ class TestVersionsPromote(MetastoreBackendTestBase):
         assert_equals(promoted_dataset['maintainer'], 'test_maintainer')
         assert_equals(
             promoted_dataset['maintainer_email'], 'test_email@example.com')
-        assert_equals(promoted_dataset['owner_org'], new_org['id'])
+        assert_equals(promoted_dataset['owner_org'], self.org['id'])
 
     # TODO: Fix this test when the convert logic is ok
     # def test_promote_version_updates_extras(self):
@@ -568,7 +559,7 @@ class TestPackageShowRevision(MetastoreBackendTestBase):
             'package_show',
             context,
             id=self.dataset['id'],
-            revision_id=initial_revision
+            revision_ref=initial_revision
             )
 
         assert_equals(initial_dataset['title'], 'Test Dataset')

--- a/ckanext/versioning/tests/test_functional.py
+++ b/ckanext/versioning/tests/test_functional.py
@@ -1,0 +1,63 @@
+from ckan.plugins import toolkit
+from ckan.tests import factories
+from ckan.tests import helpers as test_helpers
+from nose.tools import assert_equals, assert_in, assert_raises
+
+from ckanext.versioning.logic import helpers
+from ckanext.versioning.tests import MetastoreBackendTestBase
+
+
+class TestPackageShow(MetastoreBackendTestBase):
+
+    def setup(self):
+        super(TestPackageShow, self).setup()
+
+        self.user = factories.User()
+        self.user_name = self.user['name'].encode('utf8')
+
+        self.dataset = factories.Dataset()
+
+    def test_package_read_is_rendered(self):
+        app = self._get_test_app()
+
+        url = toolkit.url_for(
+            'versioning.show',
+            package_id=self.dataset['id'])
+        environ = {'REMOTE_USER': self.user_name}
+        res = app.get(url, extra_environ=environ)
+
+
+    def test_package_show_renders_master_if_not_revision(self):
+        app = self._get_test_app()
+
+        url = toolkit.url_for(
+            'versioning.show',
+            package_id=self.dataset['id'])
+        environ = {'REMOTE_USER': self.user_name}
+        res = app.get(url, extra_environ=environ)
+        assert_in(self.dataset['name'], res.ubody)
+
+
+    def test_package_show_renders_revision(self):
+        app = self._get_test_app()
+        context = self._get_context(self.user)
+
+        rev_id = helpers.get_dataset_current_revision(self.dataset['name'])
+        original_notes = self.dataset['notes']
+
+        test_helpers.call_action(
+            'package_patch',
+            context,
+            id=self.dataset['id'],
+            notes='Some changed notes',
+        )
+
+        url = toolkit.url_for(
+            'versioning.show',
+            package_id=self.dataset['id'],
+            revision_id=rev_id)
+
+        environ = {'REMOTE_USER': self.user_name}
+        res = app.get(url, extra_environ=environ)
+
+        assert_in(original_notes, res.ubody)


### PR DESCRIPTION
This PR implements #4 :

Adds a new Route `/dataset/xxx/show/{revref}/` to display the old revisions of the dataset.

### TODO:

- [ ] The new route only works with tags, since it still depends on the DatasetVersions that only creates an object when creating tags. **Define:** The whole DatasetVersions model can be removed or upgraded.
- [ ] Edit Resources is broken (not the action but the template rendering after it) since `url_for_version` fails to build a url for versioned resources
- [ ] I'm not using `frictionless_ckan_mapper`, I'm just writing into `metastore-lib` the plain `ckan_dict` since some attributes like `tracking_summary` are hard to keep track and are required by views.
- [ ] Review Docstrings and adapt to new functionality
- [ ] Fix Compare Version link
- [ ] Promote Version seems to do nothing.
- [ ] Work on resource URLs for specific revisions: `/dataset/myname/resource/xxx`  => `[implicitly] renders  /dataset/myname/show/master/{resource-id}`
- [ ] Convertion CKAN <-> Frictionless: `path`, `url`, `sha256` and `oid` fields should be handled correctly.

### Fix url_for when creating url for Resources

```
GenerationException: url_for could not generate URL. Called with args: ('resource_view',) {'resource_id': u'c02f07df-6dd3-413f-99de-946719c0ca1c', 'view_id': u'ea80df53-2372-4477-b0eb-b8e72431cf44', 'package_id': u'testing'}
```

```
Module /home/pdelboca/Repos/ckanext-versioning/ckanext/versioning/templates/package/snippets/resource_view.html:5 in top-level template code          view
>>  {% set view_url = h.url_for_version(package, resource_id=resource['id'], view_id=resource_view['id'], qualified=True, route_name='resource_view', version=c.current_version) %}
```