### PR TITLE
Templates are not rendering the version datetime correctly

### DIFF
--- a/ckanext/versioning/common.py
+++ b/ckanext/versioning/common.py
@@ -42,7 +42,7 @@ def tag_to_dict(tag):
     return {
         'package_id': tag.package_id,
         'name': tag.name,
-        'created': tag.created.isoformat(),
+        'created': tag.created.isoformat().split('+')[0],
         'revision_ref': tag.revision_ref,
         'author': tag.author.name,
         'author_email': tag.author.email,

--- a/ckanext/versioning/templates/package/read.html
+++ b/ckanext/versioning/templates/package/read.html
@@ -31,7 +31,7 @@
   {% if c.current_version %}
     <div class="module info alert alert-info">
       <p class="module-content">
-        {% set timestamp = h.render_datetime(c.current_version.created.split('+')[0], with_hours=True) %}
+        {% set timestamp = h.render_datetime(c.current_version.created, with_hours=True) %}
         {% set url = h.url_for(controller='package', action='read', id=pkg.id) %}
 
         {% trans timestamp=timestamp, url=url %}This is an old version of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current version</a>.{% endtrans %}

--- a/ckanext/versioning/templates/package/read.html
+++ b/ckanext/versioning/templates/package/read.html
@@ -31,7 +31,7 @@
   {% if c.current_version %}
     <div class="module info alert alert-info">
       <p class="module-content">
-        {% set timestamp = h.render_datetime(c.revision_date, with_hours=True) %}
+        {% set timestamp = h.render_datetime(c.current_version.created.split('+')[0], with_hours=True) %}
         {% set url = h.url_for(controller='package', action='read', id=pkg.id) %}
 
         {% trans timestamp=timestamp, url=url %}This is an old version of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current version</a>.{% endtrans %}

--- a/ckanext/versioning/templates/package/snippets/versions_list.html
+++ b/ckanext/versioning/templates/package/snippets/versions_list.html
@@ -35,7 +35,7 @@
               {{ version.description }}
             </td>
             <td class="dataset-details">
-              {{h.render_datetime(version.created.split('+')[0], with_hours=True)}}
+              {{h.render_datetime(version.created, with_hours=True)}}
             </td>
           </tr>
         {% endfor %}

--- a/ckanext/versioning/templates/package/snippets/versions_list.html
+++ b/ckanext/versioning/templates/package/snippets/versions_list.html
@@ -35,7 +35,7 @@
               {{ version.description }}
             </td>
             <td class="dataset-details">
-              {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=version.created %}
+              {{h.render_datetime(version.created.split('+')[0], with_hours=True)}}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Issue :[IVT-2717](https://gatesfoundation.atlassian.net/browse/IVT-2717)

- pass `current_version.created` date by splitting the extra part in `read.html`.
- use `h.render_datetime` function in `versions_list.html` for showing the date_time of the version in the `Published` column instead of an unimplemented snippet.
