### PR TITLE
Additional Info snippet is showing wrong data

### DIFF
--- a/ckanext/versioning/datapackage.py
+++ b/ckanext/versioning/datapackage.py
@@ -117,6 +117,8 @@ def update_ckan_dict(ckan_dict, dataset):
     ckan_dict.update(dataset)
     if len(ckan_dict.get('extras', [])) > 0:
         ckan_dict['extras'] = _normalize_extras(ckan_dict)
+    for resource in ckan_dict.get('resources'):
+        resource['package_id'] = ckan_dict.get('id')
     return ckan_dict
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ckan-datapackage-tools==0.1.0
 metastore-lib==0.1.1
 python-dateutil==2.8.1
 datapackage
-frictionless-ckan-mapper==1.0.3
+frictionless-ckan-mapper==1.0.4


### PR DESCRIPTION
Issue: [IVT-2715](https://gatesfoundation.atlassian.net/browse/IVT-2715)

- Update the `frictionless-ckan-mapper` version from `1.0.3` => `1.0.4`
- Update`update_ckan_dict()` in datapackage.py to maintain `package_id` for each resource, can be eventually use for making absolute path for the revision here `_fix_resource_data()` in action.py.