### PR TITLE
Don’t blow up when showing a dataset that is not in metastore

### DIFF
--- a/ckanext/versioning/common.py
+++ b/ckanext/versioning/common.py
@@ -1,3 +1,4 @@
+import contextlib
 from ast import literal_eval
 
 from ckan.plugins import toolkit
@@ -48,3 +49,17 @@ def tag_to_dict(tag):
         'author_email': tag.author.email,
         'description': tag.description
     }
+
+
+@contextlib.contextmanager
+def exception_mapper(from_exc, to_exc):
+    """A context manager that maps ``from_exc`` exceptions to ``to_exc``.
+
+    This is highly useful if all you want is to catch exceptions thrown by an
+    lower-level library and map them into higher level exceptions with specific
+    semantics.
+    """
+    try:
+        yield
+    except from_exc as e:
+        raise to_exc(e)

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -10,8 +10,7 @@ from ckan.logic.action.get import resource_show as core_resource_show
 from ckan.plugins import toolkit
 from metastore.backend import exc
 
-from ckanext.versioning.common import (create_author_from_context, exception_mapper,
-                                       get_metastore_backend, tag_to_dict)
+from ckanext.versioning.common import create_author_from_context, exception_mapper, get_metastore_backend, tag_to_dict
 from ckanext.versioning.datapackage import frictionless_to_dataset, update_ckan_dict
 from ckanext.versioning.logic import helpers as h
 

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -10,7 +10,8 @@ from ckan.logic.action.get import resource_show as core_resource_show
 from ckan.plugins import toolkit
 from metastore.backend import exc
 
-from ckanext.versioning.common import create_author_from_context, get_metastore_backend, tag_to_dict
+from ckanext.versioning.common import (create_author_from_context, exception_mapper,
+                                       get_metastore_backend, tag_to_dict)
 from ckanext.versioning.datapackage import frictionless_to_dataset, update_ckan_dict
 from ckanext.versioning.logic import helpers as h
 
@@ -155,7 +156,8 @@ def dataset_tag_list(context, data_dict):
 
     backend = get_metastore_backend()
 
-    tag_list = backend.tag_list(dataset.name)
+    with exception_mapper(exc.NotFound, toolkit.ObjectNotFound):
+        tag_list = backend.tag_list(dataset.name)
 
     return [tag_to_dict(t) for t in tag_list]
 
@@ -173,10 +175,8 @@ def dataset_tag_show(context, data_dict):
     """
     dataset_name, tag = toolkit.get_or_bust(data_dict, ['dataset', 'tag'])
     backend = get_metastore_backend()
-    try:
+    with exception_mapper(exc.NotFound, toolkit.ObjectNotFound):
         tag_info = backend.tag_fetch(dataset_name, tag)
-    except exc.NotFound:
-        raise toolkit.ObjectNotFound('Dataset version not found.')
 
     return tag_to_dict(tag_info)
 


### PR DESCRIPTION
This is a small fix that gracefully handles Not Found errors thrown by metastore-lib. 

While we are expected to see more issues if the dataset is not in metastore when editing, deleting or listing tags for a package, at least viewing it will work. In addition, it seemed to me that there *was* an intention for this to gracefully degrade because there is a `try/catch` around `fetch` in `plugin.py` but it catches the wrong exception. 