### PR TITLE
Fix tag name casting issue causing errors when editing tag info

### DIFF
--- a/ckanext/versioning/fanstatic/dataset_versions.js
+++ b/ckanext/versioning/fanstatic/dataset_versions.js
@@ -16,8 +16,8 @@ ckan.module('dataset_version_controls', function ($) {
             this._apiBaseUrl = this.options.apiUrl;
             this._packageId = this.options.packageId;
             this._packageUrl = this.options.packageUrl;
-            this._linkResources = (this.options.linkResources == 'True');
-            this._tag = String(this.options.tag) || null
+            this._linkResources = this.options.linkResources;
+            this._tag = this.options.tag || null;
 
             if(this._linkResources){
                 this.$(".modal-body").append(

--- a/ckanext/versioning/templates/package/snippets/versions_list.html
+++ b/ckanext/versioning/templates/package/snippets/versions_list.html
@@ -7,10 +7,10 @@
     data-module-api-url="{{ h.url_for('api.action', ver=3, logic_function='') }}"
     data-module-package-id="{{ pkg.id }}"
     data-module-package-url="{{ h.url_for(controller='package', action='read', id=pkg.name) }}"
-    data-module-link-resources="{{ h.dataset_version_has_link_resources(pkg) }}"
-    {% if c.current_version %}
-        data-module-tag="{{ c.current_version.name }}"
-    {% endif %}>
+    data-module-link-resources="{{ h.dataset_version_has_link_resources(pkg) | tojson }}"
+  {% if c.current_version %}
+    data-module-tag='{{ c.current_version.name | tojson | safe }}'
+  {% endif %}>
 
   {% if not c.revision_date %}
     <h3>Versions</h3>


### PR DESCRIPTION
JSON-encode the tag name and other variables passed into the versioning JS module

This resolves #31