### PR TITLE
Creating two tags for the same revision will cause confusion 

### DIFF
--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -89,8 +89,8 @@ def dataset_tag_create(context, data_dict):
                 'id': dataset_id_or_name,
                 'include_tracking': True
                 })
-    datapackage = dataset_to_frictionless(pkg_dict)
-    current_revision = backend.update(dataset.name,datapackage,author)
+    data_package = dataset_to_frictionless(pkg_dict)
+    current_revision = backend.update(dataset.name, data_package, author)
     try:
         tag_info = backend.tag_create(
                 dataset.name,

--- a/ckanext/versioning/logic/action.py
+++ b/ckanext/versioning/logic/action.py
@@ -12,7 +12,7 @@ from metastore.backend import exc
 from six.moves.urllib import parse
 
 from ckanext.versioning.common import create_author_from_context, exception_mapper, get_metastore_backend, tag_to_dict
-from ckanext.versioning.datapackage import frictionless_to_dataset, update_ckan_dict
+from ckanext.versioning.datapackage import frictionless_to_dataset, update_ckan_dict, dataset_to_frictionless
 from ckanext.versioning.logic import helpers as h
 
 log = logging.getLogger(__name__)
@@ -85,7 +85,12 @@ def dataset_tag_create(context, data_dict):
     # TODO: Names like 'Version 1.2' are not allowed as Github tags
     backend = get_metastore_backend()
     author = create_author_from_context(context)
-    current_revision = backend.fetch(dataset.name)
+    pkg_dict = toolkit.get_action('package_show')({}, {
+                'id': dataset_id_or_name,
+                'include_tracking': True
+                })
+    datapackage = dataset_to_frictionless(pkg_dict)
+    current_revision = backend.update(dataset.name,datapackage,author)
     try:
         tag_info = backend.tag_create(
                 dataset.name,


### PR DESCRIPTION
Issue:  [IVT-2794](https://gatesfoundation.atlassian.net/browse/IVT-2794)
 -  Update ` dataset_tag_create` method in `action.py` to make new revision_id for every tag that is going to be created whether the dataset is updated or not.