### PR TITLE
Fix exception on resource page

### DIFF
--- a/ckanext/versioning/logic/helpers.py
+++ b/ckanext/versioning/logic/helpers.py
@@ -121,3 +121,11 @@ def tojson(obj):
     be replaced with |tojson and this can be removed.
     '''
     return json.dumps(obj)
+
+
+def get_query_param(key):
+    '''
+    Get a query param from the current request. Needed for cross-ckan version support in
+    templates
+    '''
+    return toolkit.request.params.get(key)

--- a/ckanext/versioning/plugin.py
+++ b/ckanext/versioning/plugin.py
@@ -71,6 +71,7 @@ class PackageVersioningPlugin(plugins.SingletonPlugin,
             'dataset_version_has_link_resources': helpers.has_link_resources,
             'dataset_version_compare_pkg_dicts': helpers.compare_pkg_dicts,
             'tojson': helpers.tojson,
+            'versioning_get_query_param': helpers.get_query_param,
         }
 
     # IPackageController

--- a/ckanext/versioning/templates/package/snippets/resource_view.html
+++ b/ckanext/versioning/templates/package/snippets/resource_view.html
@@ -48,7 +48,7 @@
           </p>
         </div>
         {% if not to_preview %}
-          {% set current_filters = request.args.get('filters') %}
+          {% set current_filters = h.versioning_get_query_param('filters') %}
           {% if current_filters %}
             {% set src = h.url_for_revision(package, version=c.current_version,
                                            qualified=true, controller='package',

--- a/ckanext/versioning/templates/package/snippets/resource_views_list.html
+++ b/ckanext/versioning/templates/package/snippets/resource_views_list.html
@@ -12,7 +12,7 @@
       </li>
   {% endif %}
 
-  {% set current_filters = request.args.get('filters') %}
+  {% set current_filters = h.versioning_get_query_param('filters') %}
   {% for view in views %}
   	{% set is_selected = true if view_id == view.id else false %}
     {% snippet "package/snippets/resource_views_list_item.html",


### PR DESCRIPTION
```
File '/home/adria/dev/pyenvs/gates/src/ckanext-versioning/ckanext/versioning/templates/package/snippets/resource_views_list.html', line 15 in top-level template code
  {% set current_filters = request.args.get('filters') %}
File '/home/adria/dev/pyenvs/gates/lib/python2.7/site-packages/jinja2/environment.py', line 430 in getattr
  return getattr(obj, attribute)
UndefinedError: 'pylons.controllers.util.Request object' has no attribute 'args'
```


The resource view snippets were using `request.args` which is a Flask construct, but on CKAN 2.8 the resource requests are still served by Pylons, which uses `request.params`.

Added a small helper that uses `toolkit.request`, which takes care of this, for support across CKAN versions