### PR TITLE
Small Refactors on Templates

### DIFF
--- a/ckanext/versioning/templates/package/read.html
+++ b/ckanext/versioning/templates/package/read.html
@@ -13,13 +13,6 @@
   {% endif %}
 {% endblock %}
 
-{% block package_description %}
-  {{ super() }}
-  {% if c.current_release %}
-  <p>{{ c.current_release.description }}</p>
-  {% endif %}
-{% endblock %}
-
 {% block primary_content_inner %}
   {{ super() }}
   {% block release_list %}

--- a/ckanext/versioning/templates/package/read.html
+++ b/ckanext/versioning/templates/package/read.html
@@ -27,17 +27,16 @@
   {% endblock %}
 {% endblock %}
 
-{% block package_revision_info %}
-  {% if c.current_release %}
-    <div class="module info alert alert-info">
-      <p class="module-content">
-        {% set timestamp = h.render_datetime(c.current_release.created, with_hours=True) %}
-        {% set url = h.url_for(controller='package', action='read', id=pkg.id) %}
+{% block package_notes %}
+    {% if c.current_release %}
+      <div class="module info alert alert-info">
+        <p class="module-content">
+          {% set timestamp = h.render_datetime(c.current_release.created, with_hours=True) %}
+          {% set url = h.url_for(controller='package', action='read', id=pkg.id) %}
 
-        {% trans timestamp=timestamp, url=url %}This is an old revision of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current version</a>.{% endtrans %}
-      </p>
-    </div>
-  {% else %}
-    {{ super() }}
-  {% endif %}
+          {% trans timestamp=timestamp, url=url %}This is an old revision of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current version</a>.{% endtrans %}
+        </p>
+      </div>
+    {% endif %}
+  {{ super() }}
 {% endblock %}

--- a/ckanext/versioning/templates/package/resource_read.html
+++ b/ckanext/versioning/templates/package/resource_read.html
@@ -28,10 +28,10 @@
 
 {% block resource_content %}
   {% block package_revision_info %}
-    {% if c.current_release and res.revision_timestamp %}
+    {% if c.current_release and c.current_release.created %}
       <div class="module info alert alert-info">
         <p class="module-content">
-          {% set timestamp = h.render_datetime(res.revision_timestamp, with_hours=True) %}
+          {% set timestamp = h.render_datetime(c.current_release.created, with_hours=True) %}
           {% set url = h.url_for(controller='package', action='read', id=pkg.id) %}
           {% trans timestamp=timestamp, url=url %}
             This resource is from an old revision of this dataset, as edited at {{ timestamp }}.


### PR DESCRIPTION
This PR adds a small refactor on templates for better integration with other extensions and some fixes. 

I deleted the `package_description` block since it does not provide any useful information and it prints the description text in the UI with no context. (See "Initial Version" text in the next screenshot)

![initial version](https://user-images.githubusercontent.com/6672339/92926127-f3324200-f411-11ea-9a10-97fc31a6bbe0.png)
