### PR TITLE
Add a notify banner after reverting

### DIFF
--- a/ckanext/versioning/fanstatic/versioning.js
+++ b/ckanext/versioning/fanstatic/versioning.js
@@ -221,7 +221,7 @@ ckan.module('dataset_versioning_controls', function ($) {
                             'Success: ',
                             'Dataset reverted successfully. You can now go back to the main dataset page to see the changes.',
                             'success'
-                            )
+                            );
                         body.scrollTop(0);
                     }
                 }.bind(this));

--- a/ckanext/versioning/fanstatic/versioning.js
+++ b/ckanext/versioning/fanstatic/versioning.js
@@ -206,6 +206,7 @@ ckan.module('dataset_versioning_controls', function ($) {
 
         _revert: function (revision_ref, dataset) {
             const action = 'dataset_revert';
+            const body = $('html,body');
             let params = {
                 revision_ref: revision_ref,
                 dataset: dataset
@@ -216,7 +217,12 @@ ckan.module('dataset_versioning_controls', function ($) {
                     if (response.status !== 200) {
                         that._show_error_message(response, 'reverting')
                     } else {
-                        location.href = this._packageUrl;
+                        that.sandbox.notify(
+                            'Success: ',
+                            'Dataset reverted successfully. You can now go back to the main dataset page to see the changes.',
+                            'success'
+                            )
+                        body.scrollTop(0);
                     }
                 }.bind(this));
         },


### PR DESCRIPTION
When reverting a dataset, display a message to the user notifying that the action was completed successfully. I couldn't find a way to deal with redirect + flash messages using the current javascript module architecture. I decided to display a notify banner on the same page since in the close future there will be new recommendations about the UX of this extension.